### PR TITLE
Add SafeTech V3 support and disambiguate duplicate local model dropdown entries

### DIFF
--- a/custom_components/syr_connect/config_flow.py
+++ b/custom_components/syr_connect/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from typing import Any
 
 import voluptuous as vol
@@ -63,16 +64,27 @@ _STEP_REAUTH_XML_DATA_SCHEMA = vol.Schema(
 
 # Get list of models that support local JSON API (have base_path)
 # Sort by display_name to ensure first item in list matches first item shown in UI
+_LOCAL_API_MODEL_BASE = [
+    (
+        sig["name"],
+        f"{sig['manufacturer']} {sig['display_name']}",
+    )
+    for sig in MODEL_SIGNATURES
+    if sig.get("base_path") is not None
+]
+# Some distinct models share the same manufacturer + display_name (e.g. several
+# "SYR SafeTech Connect" variants), which collapse to identical dropdown entries
+# the user cannot tell apart. Disambiguate colliding labels by appending the
+# signature name, which is unique per model — so every entry stays visible and
+# selectable, and none are auto-detected away (detection uses MODEL_SIGNATURES,
+# not this list).
+_LOCAL_API_LABEL_COUNTS = Counter(label for _, label in _LOCAL_API_MODEL_BASE)
 LOCAL_API_MODELS = sorted(
     [
-        (
-            sig["name"],
-            f"{sig['manufacturer']} {sig['display_name']}",
-        )
-        for sig in MODEL_SIGNATURES
-        if sig.get("base_path") is not None
+        (name, f"{label} ({name})" if _LOCAL_API_LABEL_COUNTS[label] > 1 else label)
+        for name, label in _LOCAL_API_MODEL_BASE
     ],
-    key=lambda x: x[1].casefold(),  # Sort by display_name (case-insensitive)
+    key=lambda x: x[1].casefold(),  # Sort by label (case-insensitive)
 )
 
 # Schema for Local/JSON API configuration (host + model)

--- a/custom_components/syr_connect/helpers.py
+++ b/custom_components/syr_connect/helpers.py
@@ -917,6 +917,7 @@ def get_sensor_ala_map(status: dict[str, Any], raw_code: Any) -> tuple[str | Non
         "pontosbase",
         "safetech",
         "safetechplus",
+        "safetechv3",
         "safetechv4",
         "sanibelleakprotect",
         "sanibelsoftwaterduo",

--- a/custom_components/syr_connect/models.py
+++ b/custom_components/syr_connect/models.py
@@ -533,6 +533,15 @@ MODEL_SIGNATURES: list[dict[str, Any]] = [
     },
     {
         "base_path": "/safe-tec",
+        "display_name": "SafeTech V3 Connect",
+        "dk": 140,
+        "dkv": 35,
+        "manufacturer": "SYR",
+        "name": "safetechv3",
+        "ver_prefix": "Safe-Tech V3",
+    },
+    {
+        "base_path": "/safe-tec",
         "display_name": "SafeTech Connect",
         "dk": 140,
         "dkv": 38,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the SYR Connect config flow."""
 
+from collections import Counter
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1013,9 +1014,46 @@ def test_local_api_models_labels_prefixed_with_manufacturer() -> None:
             f"Label {label!r} for model {model_name!r} does not start with manufacturer {manufacturer!r}"
         )
         display_name = sig["display_name"]
-        assert label == f"{manufacturer} {display_name}", (
-            f"Label {label!r} != '{manufacturer} {display_name}'"
+        base = f"{manufacturer} {display_name}"
+        # Labels are normally "manufacturer display_name", but colliding labels
+        # are disambiguated with a trailing " (name)" suffix.
+        name_suffix = f"{base} ({model_name})"
+        assert label in (base, name_suffix), (
+            f"Label {label!r} != {base!r} (or its name-disambiguated form)"
         )
+
+
+def test_local_api_models_labels_are_unique() -> None:
+    """Dropdown labels must be unique.
+
+    Colliding manufacturer+display_name labels are disambiguated by appending the
+    unique signature name (e.g. the several "SafeTech Connect" variants), so no
+    two entries are indistinguishable.
+    """
+    from custom_components.syr_connect.config_flow import LOCAL_API_MODELS
+
+    labels = [label for _, label in LOCAL_API_MODELS]
+    dupes = [label for label, n in Counter(labels).items() if n > 1]
+    assert not dupes, f"Duplicate dropdown labels: {dupes!r}"
+
+
+def test_duplicate_label_models_disambiguated_by_name() -> None:
+    """Models sharing a label stay visible, disambiguated by their unique name.
+
+    safetech141 and safetech145 share "SYR SafeTech Connect" and the same
+    base_path; both remain selectable in the dropdown with distinct labels that
+    embed the signature name (nothing is hidden or collapsed).
+    """
+    from custom_components.syr_connect.config_flow import LOCAL_API_MODELS
+
+    label_by_name = {name: label for name, label in LOCAL_API_MODELS}
+
+    for name in ("safetech141", "safetech145"):
+        assert name in label_by_name, f"{name!r} missing from dropdown"
+        assert name in label_by_name[name], (
+            f"Colliding label for {name!r} should embed the name: {label_by_name[name]!r}"
+        )
+    assert label_by_name["safetech141"] != label_by_name["safetech145"]
 
 
 def test_local_api_models_only_includes_models_with_base_path() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,6 +116,34 @@ def test_safetechplus_detection_synthetic():
     assert result["manufacturer"] == "SYR"
 
 
+def test_safetech_v3_detection_local():
+    """SafeTech with 'Safe-Tech V3' firmware should be detected via ver_prefix.
+
+    Regression for a V3 unit (dk=140) reported over the local /safe-tec API
+    whose serial matches no srn_prefix and whose firmware is not 'Safe-Tech V4',
+    so it previously fell through to the unknown model.
+    """
+    flat = {
+        "getSRN": "219999999",
+        "getVER": "Safe-Tech V3.56",
+        "getTYP": "140",
+        "getAB": "1",
+        "getVLV": "20",
+    }
+    result = detect_model(flat)
+    assert result["name"] == "safetechv3"
+    assert result["display_name"] == "SafeTech V3 Connect"
+    assert result["base_path"] == "/safe-tec"
+    assert result["manufacturer"] == "SYR"
+
+
+def test_safetech_v4_not_shadowed_by_v3():
+    """Adding the V3 signature must not steal detection from V4 firmware."""
+    flat = {"getSRN": "987654321", "getVER": "Safe-Tech V4.08", "getTYP": "140"}
+    result = detect_model(flat)
+    assert result["name"] == "safetechv4"
+
+
 def test_lexplus10_with_display_name_and_base_path():
     """Verify display_name, base_path, and manufacturer are returned correctly."""
     flat = {"getCNA": "LEXplus10"}


### PR DESCRIPTION
## Summary

Adds support for **SafeTech Connect units running "Safe-Tech V3.x" firmware** (device kind `140`) over the Local/JSON API, and disambiguates duplicate model entries in the local setup dropdown.

Fixes #41.

## Background

A SafeTech reachable on the local JSON API at `/safe-tec` (firmware `Safe-Tech V3.56`, `getTYP=140`) was not identified — `detect_model()` returned `Unknown model`. None of the `dk=140` signatures match a V3: `safetechv4` requires `ver_prefix "Safe-Tech V4"`, and `safetech` requires an `srn_prefix` this serial doesn't have. Verified against real hardware via `GET /safe-tec/get/all` (login side-effect `/safe-tec/set/ADM/(2)f` → `FACTORY`); `getAB`/`getVLV` confirm the valve is exposed locally.

## Changes

- **`models.py`** — new `safetechv3` signature (`ver_prefix "Safe-Tech V3"`, `base_path "/safe-tec"`, `dk=140`). It is intentionally **not** marked `# TODO: Untested model.` because it was confirmed against a real device.
- **`helpers.py`** — add `safetechv3` to the alarm-code mapping family (next to `safetech`/`safetechv4`) so V3 alarm codes are translated.
- **`config_flow.py`** — several models share the label `SYR SafeTech Connect`, producing indistinguishable dropdown entries (one maps to `/trio`, others to `/safe-tec`). Colliding labels are now disambiguated by appending the unique signature `name`, e.g. `SYR SafeTech Connect (safetech141)`. Only applied when a label actually collides. Nothing is hidden or removed — detection uses `MODEL_SIGNATURES`, not this dropdown list, so auto-identification is unaffected.
- **`tests/`** — V3 detection + a regression that V4 firmware is not shadowed by the new V3 prefix; dropdown label uniqueness + that colliding models stay visible and distinctly labeled.

## Verification

- `pytest` — full suite green (1485 passed, 1 xfailed).
- `ruff check` — clean.

## Note for maintainer

`safetech141` (dk=141) and `safetech145` (dk=145) remain functionally identical for the local API (same `/safe-tec`, no detection keys, differ only by device-kind). This PR keeps both and makes them distinguishable in the UI rather than removing either. If you'd prefer them to auto-detect distinctly, they'd need `attrs_equals` on `getTYP` — I left that out since I have no `dk=141`/`145` capture to verify against. Happy to follow up.
